### PR TITLE
Implement: support UTC during timezone name parsing 

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -2,6 +2,7 @@ import {convertTimesToLocal} from './time';
 
 test('convertTimesToLocal', () => {
     const testCases = [
+
         // This is an incorrect test case that demonstrates the issue with this plugin. 10am ET is not 8am pacific time at the refrence time.
         // Additional tests shoudl be written if we find a solution to this.
         {
@@ -18,8 +19,8 @@ test('convertTimesToLocal', () => {
 test('timezoneParsing', () => {
     const testCases = [
         {
-            test: "The game is at 12pm UTC",
-            expected: "The game is `at 12pm UTC` *(Mon, Aug 23, 2021 1:00 PM BST)*",
+            test: 'The game is at 12pm UTC',
+            expected: 'The game is `at 12pm UTC` *(Mon, Aug 23, 2021 1:00 PM BST)*',
         },
     ];
 

--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -19,11 +19,11 @@ test('timezoneParsing', () => {
     const testCases = [
         {
             test: "The game is at 12pm UTC",
-            expected: "The game is `at 12pm UTC` *(Mon, Jan 19, 1970 1:00 PM BST)*",
+            expected: "The game is `at 12pm UTC` *(Mon, Aug 23, 2021 1:00 PM BST)*",
         },
     ];
 
     testCases.forEach((tc) => {
-        expect(convertTimesToLocal(tc.test, 1629738610, 'Europe/London', 'en')).toEqual(tc.expected);
+        expect(convertTimesToLocal(tc.test, 1629738610000, 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });

--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -2,7 +2,6 @@ import {convertTimesToLocal} from './time';
 
 test('convertTimesToLocal', () => {
     const testCases = [
-
         // This is an incorrect test case that demonstrates the issue with this plugin. 10am ET is not 8am pacific time at the refrence time.
         // Additional tests shoudl be written if we find a solution to this.
         {
@@ -13,5 +12,18 @@ test('convertTimesToLocal', () => {
 
     testCases.forEach((tc) => {
         expect(convertTimesToLocal(tc.test, 1563387832493, 'America/Vancouver', 'en')).toEqual(tc.expected);
+    });
+});
+
+test('timezoneParsing', () => {
+    const testCases = [
+        {
+            test: "The game is at 12pm UTC",
+            expected: "The game is `at 12pm UTC` *(Mon, Jan 19, 1970 1:00 PM BST)*",
+        },
+    ];
+
+    testCases.forEach((tc) => {
+        expect(convertTimesToLocal(tc.test, 1629738610, 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -25,7 +25,7 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
         }
 
         const anchorTimezoneStart = parsedTime.start.knownValues.timezoneOffset;
-        if (anchorTimezoneStart === undefined) {
+        if (typeof anchorTimezoneStart === 'undefined') {
             return message;
         }
 

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -25,7 +25,7 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
         }
 
         const anchorTimezoneStart = parsedTime.start.knownValues.timezoneOffset;
-        if (!anchorTimezoneStart) {
+        if (anchorTimezoneStart === undefined) {
             return message;
         }
 


### PR DESCRIPTION
#### Summary
Adds support for parsing of time strings that use `UTC` as an offset; for example, "let's meet tomorrow at 4pm UTC"

#### Ticket Link
Resolves #36 