### PR TITLE
Omit date-part from rendering when parsed times do not mention a day or weekday

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -20,7 +20,15 @@ test('timezoneParsing', () => {
     const testCases = [
         {
             test: 'The game is at 12pm UTC',
-            expected: 'The game is `at 12pm UTC` *(Mon, Aug 23 1:00 PM BST)*',
+            expected: 'The game is `at 12pm UTC` *(1:00 PM BST)*',
+        },
+        {
+            test: 'Last deploy is Thursday at 11:59pm UTC',
+            expected: 'Last deploy is `Thursday at 11:59pm UTC` *(Fri, Aug 27 12:59 AM BST)*',
+        },
+        {
+            test: 'Last deploy is at 11:59pm UTC',
+            expected: 'Last deploy is `at 11:59pm UTC` *(12:59 AM BST)*',
         },
     ];
 

--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -20,7 +20,7 @@ test('timezoneParsing', () => {
     const testCases = [
         {
             test: 'The game is at 12pm UTC',
-            expected: 'The game is `at 12pm UTC` *(Mon, Aug 23, 2021 1:00 PM BST)*',
+            expected: 'The game is `at 12pm UTC` *(Mon, Aug 23 1:00 PM BST)*',
         },
     ];
 

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -4,6 +4,7 @@ import moment from 'moment-timezone';
 const DATE_AND_TIME_FORMAT = 'ddd, MMM D LT';
 const ZONE_FORMAT = 'z';
 const TIME_FORMAT = 'LT';
+const DATE_FORMAT = 'llll';
 
 // Disable zh-Hant support in the default chrono parser
 chrono.casual.parsers = chrono.casual.parsers.filter((parser) => {
@@ -34,14 +35,14 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
 
         const currentUserStartDate = moment(parsedTime.start.date()).tz(localTimezone).locale(locale);
         if (!currentUserStartDate.isSame(moment(), 'year')) {
-            renderingFormat = 'llll';
+            renderingFormat = DATE_FORMAT;
         } else if (typeof parsedTime.start.knownValues.day === 'undefined' && typeof parsedTime.start.knownValues.weekday === 'undefined') {
             renderingFormat = TIME_FORMAT;
         }
         if (parsedTime.end) {
             const currentUserEndDate = moment(parsedTime.end.date()).tz(localTimezone).locale(locale);
             if (!currentUserEndDate.isSame(moment(), 'year')) {
-                renderingFormat = 'llll';
+                renderingFormat = DATE_FORMAT;
             }
             if (currentUserStartDate.isSame(currentUserEndDate, 'day')) {
                 formattedDisplayDate = `${currentUserStartDate.format(renderingFormat)} - ${currentUserEndDate.format(TIME_FORMAT + ' ' + ZONE_FORMAT)}`;

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -25,8 +25,7 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
             continue;
         }
 
-        const anchorTimezoneStart = parsedTime.start.knownValues.timezoneOffset;
-        if (typeof anchorTimezoneStart === 'undefined') {
+        if (!parsedTime.start.isCertain('timezoneOffset')) {
             return message;
         }
 
@@ -36,7 +35,7 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
         const currentUserStartDate = moment(parsedTime.start.date()).tz(localTimezone).locale(locale);
         if (!currentUserStartDate.isSame(moment(), 'year')) {
             renderingFormat = DATE_FORMAT;
-        } else if (typeof parsedTime.start.knownValues.day === 'undefined' && typeof parsedTime.start.knownValues.weekday === 'undefined') {
+        } else if (!parsedTime.start.isCertain('day') && !parsedTime.start.isCertain('weekday')) {
             renderingFormat = TIME_FORMAT;
         }
         if (parsedTime.end) {

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -35,6 +35,8 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
         const currentUserStartDate = moment(parsedTime.start.date()).tz(localTimezone).locale(locale);
         if (!currentUserStartDate.isSame(moment(), 'year')) {
             renderingFormat = 'llll';
+        } else if (typeof parsedTime.start.knownValues.day === 'undefined' && typeof parsedTime.start.knownValues.weekday === 'undefined') {
+            renderingFormat = TIME_FORMAT;
         }
         if (parsedTime.end) {
             const currentUserEndDate = moment(parsedTime.end.date()).tz(localTimezone).locale(locale);

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -1,7 +1,7 @@
 import chrono from 'chrono-node';
 import moment from 'moment-timezone';
 
-let DATE_AND_TIME_FORMAT = 'ddd, MMM D LT';
+const DATE_AND_TIME_FORMAT = 'ddd, MMM D LT';
 const ZONE_FORMAT = 'z';
 const TIME_FORMAT = 'LT';
 
@@ -29,24 +29,25 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
             return message;
         }
 
+        let renderingFormat = DATE_AND_TIME_FORMAT;
         let formattedDisplayDate;
 
         const currentUserStartDate = moment(parsedTime.start.date()).tz(localTimezone).locale(locale);
         if (!currentUserStartDate.isSame(moment(), 'year')) {
-            DATE_AND_TIME_FORMAT = 'llll';
+            renderingFormat = 'llll';
         }
         if (parsedTime.end) {
             const currentUserEndDate = moment(parsedTime.end.date()).tz(localTimezone).locale(locale);
             if (!currentUserEndDate.isSame(moment(), 'year')) {
-                DATE_AND_TIME_FORMAT = 'llll';
+                renderingFormat = 'llll';
             }
             if (currentUserStartDate.isSame(currentUserEndDate, 'day')) {
-                formattedDisplayDate = `${currentUserStartDate.format(DATE_AND_TIME_FORMAT)} - ${currentUserEndDate.format(TIME_FORMAT + ' ' + ZONE_FORMAT)}`;
+                formattedDisplayDate = `${currentUserStartDate.format(renderingFormat)} - ${currentUserEndDate.format(TIME_FORMAT + ' ' + ZONE_FORMAT)}`;
             } else {
-                formattedDisplayDate = `${currentUserStartDate.format(DATE_AND_TIME_FORMAT + ' ' + ZONE_FORMAT)} - ${currentUserEndDate.format(DATE_AND_TIME_FORMAT + ' ' + ZONE_FORMAT)}`;
+                formattedDisplayDate = `${currentUserStartDate.format(renderingFormat + ' ' + ZONE_FORMAT)} - ${currentUserEndDate.format(renderingFormat + ' ' + ZONE_FORMAT)}`;
             }
         } else {
-            formattedDisplayDate = currentUserStartDate.format(DATE_AND_TIME_FORMAT + ' ' + ZONE_FORMAT);
+            formattedDisplayDate = currentUserStartDate.format(renderingFormat + ' ' + ZONE_FORMAT);
         }
 
         const {text} = parsedTime;


### PR DESCRIPTION
#### Summary
If a parsed time does not feature a date, then do not render a date in the localized time format string.

#### Ticket Link
Partially addresses #11 (but does not fix it completely).

