### PR TITLE
Refactor timestamp rendering

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -34,6 +34,10 @@ test('timezoneParsing', () => {
             test: 'Meeting scheduled for 10am GMT+2',
             expected: 'Meeting scheduled for `10am GMT+2` *(9:00 AM BST)*',
         },
+        {
+            test: 'Some time around for 5pm-6pm UTC',
+            expected: 'Some time around for `5pm-6pm UTC` *(6:00 PM - 7:00 PM BST)*',
+        },
 
         // The word 'now' should not be rendered with a local time, although chrono-node can identify it as a time reference
         {

--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -68,3 +68,16 @@ test('timezoneParsing', () => {
         expect(convertTimesToLocal(tc.test, 1629738610000, 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });
+
+test('crossDaylightSavings', () => {
+    const testCases = [
+        {
+            test: 'Today from 2pm - 7pm PDT',
+            expected: '`Today from 2pm - 7pm PDT` *(Sat, Oct 30 10:00 PM BST - Sun, Oct 31 2:00 AM GMT)*',
+        },
+    ];
+
+    testCases.forEach((tc) => {
+        expect(convertTimesToLocal(tc.test, 1635562800000, 'Europe/London', 'en')).toEqual(tc.expected);
+    });
+});

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -23,10 +23,7 @@ function relativeRenderingFormat(current, previous) {
     if (!current.isCertain('day') && !current.isCertain('weekday')) {
         format = TIME_FORMAT;
     }
-    if (!currentMoment.isSame(previousMoment, 'day')) {
-        format = format + ' ' + ZONE_FORMAT;
-    }
-    return format;
+    return format + ' ' + ZONE_FORMAT;
 }
 
 // Render a parsed time relative to an (optional) previous parsed time

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -1,10 +1,9 @@
 const chrono = require('chrono-node');
 const moment = require('moment-timezone');
 
-const YEAR_DATE_AND_TIME_FORMAT = 'llll';
-const DATE_AND_TIME_FORMAT = 'ddd, MMM D LT';
-const ZONE_FORMAT = 'z';
-const TIME_FORMAT = 'LT';
+const YEAR_DATE_AND_TIME_FORMAT = 'llll z';
+const DATE_AND_TIME_FORMAT = 'ddd, MMM D LT z';
+const TIME_FORMAT = 'LT z';
 
 // Disable zh-Hant support in the default chrono parser
 chrono.casual.parsers = chrono.casual.parsers.filter((parser) => {
@@ -23,7 +22,7 @@ function relativeRenderingFormat(current, previous) {
     if (!current.isCertain('day') && !current.isCertain('weekday')) {
         format = TIME_FORMAT;
     }
-    return format + ' ' + ZONE_FORMAT;
+    return format;
 }
 
 // Render a parsed time relative to an (optional) previous parsed time

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -23,11 +23,13 @@ function relativeRenderingFormat(previous, current, next) {
     if (!current.isCertain('day') && !current.isCertain('weekday')) {
         format = TIME_FORMAT;
     }
+
     // Edge case: if the UTC offset on the next timestamp in the range is different, include the timezone code
     // This can happen if a time range crosses a daylight savings change
-    if (next && currentMoment.utcOffset() != nextMoment.utcOffset()) {
+    if (next && currentMoment.utcOffset() !== nextMoment.utcOffset()) {
         format += ' z';
     }
+
     // Include the timezone code on the last formatted timestamp
     if (!next) {
         format += ' z';

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -50,11 +50,10 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
     if (!parsedTimes || !parsedTimes.length) {
         return message;
     }
-    let newMessage = message;
+    let localizedMessage = message;
 
     for (let i = 0, len = parsedTimes.length; i < len; i++) {
         const parsedTime = parsedTimes[i];
-
         if (!parsedTime.start.isCertain('timezoneOffset')) {
             return message;
         }
@@ -63,10 +62,7 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
         if (parsedTime.end) {
             formattedDisplayDate += ' - ' + renderRelativeTimestamp(parsedTime.start, parsedTime.end, null, localTimezone, locale);
         }
-
-        const {text} = parsedTime;
-        newMessage = `${newMessage.replace(text, `\`${text}\` *(${formattedDisplayDate})*`)}`;
+        localizedMessage = localizedMessage.replace(parsedTime.text, `\`${parsedTime.text}\` *(${formattedDisplayDate})*`);
     }
-
-    return newMessage;
+    return localizedMessage;
 }

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -26,12 +26,12 @@ function relativeRenderingFormat(previous, current, next) {
 
     // Edge case: if the UTC offset on the next timestamp in the range is different, include the timezone code
     // This can happen if a time range crosses a daylight savings change
-    if (next && currentMoment.utcOffset() !== nextMoment.utcOffset()) {
+    if (next !== null && currentMoment.utcOffset() !== nextMoment.utcOffset()) {
         format += ' z';
     }
 
     // Include the timezone code on the last formatted timestamp
-    if (!next) {
+    if (next === null) {
         format += ' z';
     }
     return format;


### PR DESCRIPTION
#### Summary
This is a possible refactoring for the rendering of localized timestamps within the plugin's JavaScript code.

The initial idea was to reduce near-duplicate logic across rendering of the `start` and `end` timestamps.

In practice there are a few small details that need to be taken care of: in particular, start times are rendered relative to the current time, and end times are rendered relative to the start time.

This is all optional and I'd be glad to chat about alternatives or limitations of this refactor.

Issue #42 was discovered during this refactoring and is addressed by it.

#### Ticket Link
Resolves #42.