### PR TITLE
Add a cross-daylight-savings time range test case

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -64,3 +64,16 @@ test('timezoneParsing', () => {
         expect(convertTimesToLocal(tc.test, 1629738610000, 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });
+
+test('crossDaylightSavings', () => {
+    const testCases = [
+        {
+            test: 'Today from 2pm - 7pm PDT',
+            expected: '`Today from 2pm - 7pm PDT` *(Sat, Oct 30 10:00 PM BST - Sun, Oct 31 2:00 AM GMT)*',
+        },
+    ];
+
+    testCases.forEach((tc) => {
+        expect(convertTimesToLocal(tc.test, 1635562800000, 'Europe/London', 'en')).toEqual(tc.expected);
+    });
+});


### PR DESCRIPTION
#### Summary
Issue #42 describes a scenario in which a date range parsed by the plugin crosses a daylight savings boundary.

Even though it was confirmed that the mainline code already handles this correctly, we can still add test coverage to prove that and avoid regressions in future.

This changeset adds a test case for this scenario.

#### Ticket Link
Provides regression safety for #42.