### PR TITLE
[contrib] GitLab CI/CD configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ deploy-test:
   needs:
     - bundle
   before_script:
-    - mmctl auth login ${MATTERMOST_TEST_URI} --name deployment --access-token ${MATTERMOST_ACCESS_KEY_TEST}
+    - mmctl auth login ${MATTERMOST_TEST_URI} --name deployment --access-token ${MATTERMOST_TEST_ACCESS_KEY}
   script:
     - mmctl plugin add --force dist/${BUNDLE_NAME}
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,72 @@
+stages:
+  - lint
+  - build
+  - test
+  - deploy
+
+variables:
+  BUNDLE_NAME: "mattermost-plugin-walltime.tar.gz"
+
+lint:
+  stage: lint
+  image: golangci/golangci-lint
+  before_script:
+    - apt -y update
+    - apt -y install npm
+  script:
+    - make check-style
+
+server:
+  image: golang:1.16-bullseye
+  stage: build
+  before_script:
+    - apt -y update
+    - apt -y install npm
+  script:
+    - make server
+  artifacts:
+    paths:
+      - "server/dist/*"
+
+webapp:
+  image: golang:1.16-bullseye
+  stage: build
+  before_script:
+    - apt -y update
+    - apt -y install npm
+  script:
+    - make webapp
+  artifacts:
+    paths:
+      - "webapp/dist/*"
+
+bundle:
+  image: golang:1.16-bullseye
+  stage: test
+  dependencies:
+    - server
+    - webapp
+  before_script:
+    - apt -y update
+    - apt -y install npm
+  script:
+    - make test
+    - make bundle
+  artifacts:
+    paths:
+      - "dist/*.tar.gz"
+
+deploy-test:
+  stage: deploy
+  image: mattermost/mattermost-team-edition
+  needs:
+    - bundle
+  before_script:
+    - mmctl auth login https://test.chat.collabora.com/ --name deployment --access-token ${MATTERMOST_ACCESS_KEY_TEST}
+  script:
+    - mmctl plugin delete com.mattermost.walltime-plugin || true  # TODO: remove if-and-when https://github.com/mattermost/mmctl/issues/382 is provided
+    - mmctl plugin add dist/${BUNDLE_NAME}
+    - mmctl plugin enable com.mattermost.walltime-plugin # TODO: remove if-and-when https://github.com/mattermost/mmctl/issues/382 is provided
+  after_script:
+    - mmctl auth delete deployment
+  when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ deploy-test:
   needs:
     - bundle
   before_script:
-    - mmctl auth login https://test.chat.collabora.com/ --name deployment --access-token ${MATTERMOST_ACCESS_KEY_TEST}
+    - mmctl auth login ${MATTERMOST_TEST_URI} --name deployment --access-token ${MATTERMOST_ACCESS_KEY_TEST}
   script:
     - mmctl plugin add --force dist/${BUNDLE_NAME}
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ bundle:
 
 deploy-test:
   stage: deploy
-  image: mattermost/mattermost-team-edition
+  image: mattermost/mattermost-team-edition:release-6.2
   needs:
     - bundle
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,9 +64,7 @@ deploy-test:
   before_script:
     - mmctl auth login https://test.chat.collabora.com/ --name deployment --access-token ${MATTERMOST_ACCESS_KEY_TEST}
   script:
-    - mmctl plugin delete com.mattermost.walltime-plugin || true  # TODO: remove if-and-when https://github.com/mattermost/mmctl/issues/382 is provided
-    - mmctl plugin add dist/${BUNDLE_NAME}
-    - mmctl plugin enable com.mattermost.walltime-plugin # TODO: remove if-and-when https://github.com/mattermost/mmctl/issues/382 is provided
+    - mmctl plugin add --force dist/${BUNDLE_NAME}
   after_script:
     - mmctl auth delete deployment
   when: manual


### PR DESCRIPTION
#### Summary
This changeset provides a GitLab CI/CD configuration to lint, test, bundle and deploy* the plugin.

We use this internally at @collabora and the configuration provided here is the [same one used](https://gitlab.collabora.com/tools/mattermost/mattermost-plugin-walltime/-/blob/da8fd030ef43f4b0acaf5789b1b0bc10c4b392b2/.gitlab-ci.yml) in our public fork/mirror of the plugin.

*deployment is only provided to a test environment, currently - this could be extended

#### Ticket Link
N/A

