### PR TITLE
Address handling of ambiguous timezone references

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -88,3 +88,13 @@ test('crossDaylightSavings', () => {
         expect(convertTimesToLocal(tc.test, 1635562800000, 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });
+
+test('avoidTimezoneTokenAmbiguity', () => {
+    const testCases = [
+        "People visiting Buñol towards the end of August get a good chance to participate in La Tomatina (under normal circumstances)",
+    ];
+
+    testCases.forEach((input) => {
+        expect(convertTimesToLocal(input, 1642761512000, 'America/Vancouver', 'en')).toEqual(input);
+    });
+});


### PR DESCRIPTION
#### Summary
Aims to address incorrect interpretation of ambiguous tokens (for example, the word `get` following a month name) as timezones by the plugin.

#### Ticket Link
Resolves #53.