### PR TITLE
Address handling of ambiguous timezone references

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5,13 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "webapp",
       "version": "0.1.1",
       "dependencies": {
+        "chrono-node": "2.3.9",
+        "mattermost-redux": "",
         "moment-timezone": "0.5.26",
         "react": "16.8.6",
         "react-redux": "5.0.7",
-        "mattermost-redux": "",
-        "chrono-node": "2.3.4",
         "redux": "4.0.4"
       },
       "devDependencies": {
@@ -3662,7 +3663,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -3704,9 +3704,9 @@
       }
     },
     "node_modules/chrono-node": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.3.4.tgz",
-      "integrity": "sha512-FxVbEoT1XU/HgObJvHaT2Ad2B6yqsnvV6MshyrBGhskCtKliVgl+bi0bS4GuItxHhxaCAZqDRYeLaAR15MGf3A==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.3.9.tgz",
+      "integrity": "sha512-Qg6zmsGwaWzWiMKapr060sL6zgfBIkTxnyCTd7KGQ0YDTYg0VvBfqRRBuaOkGjiVGdKPM/cp4QQTLcpUhZQxXg==",
       "dependencies": {
         "dayjs": "^1.10.0"
       }
@@ -4545,8 +4545,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8643,7 +8642,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
@@ -17539,9 +17537,9 @@
       }
     },
     "chrono-node": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.3.4.tgz",
-      "integrity": "sha512-FxVbEoT1XU/HgObJvHaT2Ad2B6yqsnvV6MshyrBGhskCtKliVgl+bi0bS4GuItxHhxaCAZqDRYeLaAR15MGf3A==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.3.9.tgz",
+      "integrity": "sha512-Qg6zmsGwaWzWiMKapr060sL6zgfBIkTxnyCTd7KGQ0YDTYg0VvBfqRRBuaOkGjiVGdKPM/cp4QQTLcpUhZQxXg==",
       "requires": {
         "dayjs": "^1.10.0"
       }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "3.3.6"
   },
   "dependencies": {
-    "chrono-node": "2.3.4",
+    "chrono-node": "2.3.9",
     "mattermost-redux": "",
     "moment-timezone": "0.5.26",
     "react": "16.8.6",

--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -88,3 +88,13 @@ test('crossDaylightSavings', () => {
         expect(convertTimesToLocal(tc.test, 1635562800000, 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });
+
+test('avoidTimezoneTokenAmbiguity', () => {
+    const testCases = [
+        'People visiting Buñol towards the end of August get a good chance to participate in La Tomatina (under normal circumstances)',
+    ];
+
+    testCases.forEach((input) => {
+        expect(convertTimesToLocal(input, 1642761512000, 'America/Vancouver', 'en')).toEqual(input);
+    });
+});


### PR DESCRIPTION
Reopen of https://github.com/mattermost/mattermost-plugin-walltime/pull/54
#### Summary

Aims to address incorrect interpretation of ambiguous tokens (for example, the word `get` following a month name) as timezones by the plugin.
#### Ticket Link

Resolves #53.

