### PR TITLE
Allow localization of parsed times when some of them do not have a timezone offset

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -66,6 +66,12 @@ test.each([
         test: 'Sunday at 4pm GMT',
         expected: '`Sunday at 4pm GMT` *(Sun, Aug 29 5:00 PM BST)*',
     },
+
+    // Times should still be localized when another time duration is mentioned later in the sentence
+    {
+        test: 'Today at 16:30 CET and then we will take a 15 minute break',
+        expected: '`Today at 16:30 CET` *(Mon, Aug 23, 2021 4:30 PM BST)* and then we will take a 15 minute break',
+    },
 ])('timezoneParsing: "$test"', ({now, test, expected}) => {
     // Some of the library's logic is currently not 'stable', because, for example, we call moment() without arguments
     // A few of our test cases are therefore pinned to specific points-in-time, pending temporal stability

--- a/webapp/src/time.js
+++ b/webapp/src/time.js
@@ -23,7 +23,7 @@ export function convertTimesToLocal(message, messageCreationTime, localTimezone,
         const parsedTime = parsedTimes[i];
 
         if (!parsedTime.start.isCertain('timezoneOffset')) {
-            return message;
+            continue;
         }
 
         let renderingFormat = DATE_AND_TIME_FORMAT;


### PR DESCRIPTION
Reopen of #56
#### Summary

As described in #55, the existing plugin logic is that the presence of any parsed time without a timezone in a message will cause localization of the message to be skipped (the original, unmodified message will be returned to the caller).

This change skips over parsed times if they do not have a timezone offset associated with them; this allows localization of any other parsed times discovered within the message.
#### Ticket Link

Resolves #55.