### PR TITLE
[GH-61] Fix broken test & revise tests to use human-readable date strings rather than epochs

### DIFF
--- a/webapp/src/test.js
+++ b/webapp/src/test.js
@@ -1,5 +1,9 @@
 import {convertTimesToLocal} from './time';
 
+function convertDateStringToEpoch(dateString) {
+    return new Date(dateString).getTime();
+}
+
 beforeEach(() => {
     jest.useFakeTimers();
 });
@@ -10,14 +14,14 @@ afterEach(() => {
 
 test.each([
 
-    // This is an incorrect test case that demonstrates the issue with this plugin. 10am ET is not 8am pacific time at the refrence time.
+    // This is an incorrect test case that demonstrates the issue with this plugin. 10am ET is not 8am pacific time at the reference time.
     // Additional tests shoudl be written if we find a solution to this.
     {
         test: "Let's meet today at 10am ET",
         expected: "Let's meet `today at 10am ET` *(Wed, Jul 17, 2019 8:00 AM PDT)*",
     },
 ])('convertTimesToLocal: "$test"', ({test, expected}) => {
-    expect(convertTimesToLocal(test, 1563387832493, 'America/Vancouver', 'en')).toEqual(expected);
+    expect(convertTimesToLocal(test, convertDateStringToEpoch('2019-07-17 18:23:52.493 +0000'), 'America/Vancouver', 'en')).toEqual(expected);
 });
 
 test.each([
@@ -78,7 +82,7 @@ test.each([
     if (now) {
         jest.setSystemTime(now);
     }
-    expect(convertTimesToLocal(test, 1629738610000, 'Europe/London', 'en')).toEqual(expected);
+    expect(convertTimesToLocal(test, convertDateStringToEpoch('2021-08-23 17:10:10 +0000'), 'Europe/London', 'en')).toEqual(expected);
 });
 
 test('crossDaylightSavings', () => {
@@ -90,8 +94,8 @@ test('crossDaylightSavings', () => {
     ];
 
     testCases.forEach((tc) => {
-        jest.setSystemTime(new Date(1638965948000));
-        expect(convertTimesToLocal(tc.test, 1635562800000, 'Europe/London', 'en')).toEqual(tc.expected);
+        jest.setSystemTime(new Date('2021-12-08 12:19:08 +0000'));
+        expect(convertTimesToLocal(tc.test, convertDateStringToEpoch('2021-10-30 08:00:56 -0700'), 'Europe/London', 'en')).toEqual(tc.expected);
     });
 });
 
@@ -101,6 +105,6 @@ test('avoidTimezoneTokenAmbiguity', () => {
     ];
 
     testCases.forEach((input) => {
-        expect(convertTimesToLocal(input, 1642761512000, 'America/Vancouver', 'en')).toEqual(input);
+        expect(convertTimesToLocal(input, convertDateStringToEpoch('2022-01-21 10:38:32 +0000'), 'America/Vancouver', 'en')).toEqual(input);
     });
 });


### PR DESCRIPTION
#### Summary
On master (29f710be3187d7dbe44ab348b18acc90131f47ee), running `make` with no changes causes a test failure in the `crossDaylightSavings` test.

The issue is that the message received timestamp used is epoch `1635562800000`, which is `Saturday, October 30, 2021 3:00:00 AM GMT`.

The test string used is `Today from 2pm - 7pm PDT`

As a result, the test string is interpreted as Oct 29th in PDT, not Oct 30, and so the test fails, because it's expecting `Today from 2pm - 7pm PDT *(Sat, Oct 30 10:00 PM BST - Sun, Oct 31 2:00 AM GMT)*` as a result.

As part of correcting this timestamp, I also changed all the timestamps in that file to be human-readable (but kept the equivalent timestamps). Hopefully this will prevent something like this in the future. (And if not, at least it makes it easier to debug tests since you don't have to use an epoch converter to double-check).

I also fixed a couple typos since they were trivial and in the same file.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-walltime/issues/61